### PR TITLE
Update tutorial to new cdk-dynamo-table-view versopm 

### DIFF
--- a/workshop/content/english/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/english/30-python/50-table-viewer/200-install.md
@@ -11,7 +11,7 @@ the python module. Add this code to `requirements.txt`:
 {{<highlight python "hl_lines=3">}}
 aws-cdk-lib==2.37.0
 constructs>=10.0.0,<11.0.0
-cdk-dynamo-table-view==0.2.0
+cdk-dynamo-table-view==0.2.486
 {{</highlight>}}
 
 Once the virtualenv is activated, you can install the required dependencies.


### PR DESCRIPTION
The combo of `cdk-dynamo-table-view==0.2.0` and cdk version `2.92.0 (build bf62e55)` was leading to an error: 

```
 ❌  cdk-workshop failed: Error: The stack named cdk-workshop failed to deploy: UPDATE_ROLLBACK_COMPLETE: Resource handler returned message: "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: ddfbc7a5-8512-48a6-9ae1-8a106599d075)" (RequestToken: 2bb17d31-2d61-fba8-3691-8904f0539cf4, HandlerErrorCode: InvalidRequest)
```

Updating the library solved the issue. 